### PR TITLE
Use live image for main product image

### DIFF
--- a/src/_layouts/product-page.html
+++ b/src/_layouts/product-page.html
@@ -7,9 +7,12 @@ layout: default
 </header>
 
 <div class="product-collage">
-  <span><img src="//placehold.it/790x508"></span>
+  <div class="product-collage__image product-collage__image--main">
+    <img src="/assets/images/products/{{ page.sku | downcase }}/live.jpg">
+  </div>
+
   {% if page.rotator == true %}
-    <span class="spritespin"></span>
+    <div class="product-collage__sprite spritespin"></div>
     <script>
       var sku = "{{ page.sku | downcase }}",
         imageWidth = 538,
@@ -17,14 +20,13 @@ layout: default
         rotator = "{{ page.rotator }}"
     </script>
   {% else %}
-    <span><img src="//placehold.it/378x507"></span>
+    <div class="product-collage__image product-collage__image--sprite">
+      <img src="//placehold.it/378x507">
+    </div>
   {% endif %}
 </div>
 
-
-
 <div class="product-body">
-
   <article class="product-article">
     <h2 class="product-article__title">Description & Features</h2>
     <div class="product-article__wrapper">

--- a/src/assets/css/_sass/pages/_product.scss
+++ b/src/assets/css/_sass/pages/_product.scss
@@ -40,18 +40,26 @@
   position: relative;
   padding: -size(26px);
   background-color: -color($greys, 95);
-  display: grid;
-  grid-gap: -size(13px);
+  display: flex;
+  justify-content: space-between;
   @include margin-center;
 
-  span {
-    grid-column: 2 / 2;
+  .product-collage__image {
     overflow: hidden;
+
+    img {
+      min-width: 100%;
+      min-height: 100%;
+    }
   }
 
-  span:nth-of-type(1) {
-    grid-column: 1 / 2;
-    grid-row: 1 / 3;
+  .product-collage__image--main {
+    flex-grow: 2;
+    margin-right: -size(16px);
+  }
+
+  .product-collage__image--sprite {
+    flex-shrink: 1;
   }
 }
 


### PR DESCRIPTION
#51 

Replaces grid with flex + image wrapper. I went with this over css
classes with background-size: cover, to avoid having to print out each
class inside the css. I could have made it inline to fix that, but still
kind of crude.