### PR TITLE
Contact page touch-ups

### DIFF
--- a/src/assets/css/_sass/pages/_contact.scss
+++ b/src/assets/css/_sass/pages/_contact.scss
@@ -8,6 +8,7 @@
   display: flex;
   height: -size(488px);
   justify-content: center;
+  padding: 0 30px;
 }
 
 .contact-hero__title {
@@ -48,7 +49,7 @@
   flex-flow: column;
   justify-content: space-between;
   height: 720px;
-  padding: 25px;
+  padding: 30px 30px 0;
   margin: 60px auto 60px;
   width: 800px;
   max-width: 95%;

--- a/src/assets/css/_sass/pages/_contact.scss
+++ b/src/assets/css/_sass/pages/_contact.scss
@@ -8,7 +8,6 @@
   display: flex;
   height: -size(488px);
   justify-content: center;
-  padding: 0 30px;
 }
 
 .contact-hero__title {
@@ -22,7 +21,6 @@
 
 .contact-hero__intro {
   text-align: center;
-  max-width: 900px;
   transform: translateY(-size(50px));
   @include text-shadow;
 }
@@ -44,9 +42,6 @@
   margin-top: 120px;
   margin-bottom: 120px;
   width: 800px;
-  max-width: 95%;
-  background: white;
-  color: $color-grey--darker;
 
   .contact-page__field {
     display: flex;

--- a/src/assets/css/_sass/pages/_contact.scss
+++ b/src/assets/css/_sass/pages/_contact.scss
@@ -36,21 +36,13 @@
   }
 }
 
-.contact-page__section {
-  position: relative;
-  flex-flow: column;
-  justify-content: center;
-  align-items: center;
-  margin-bottom: 80px;
-}
-
 .contact-page__form {
   display: flex;
   flex-flow: column;
   justify-content: space-between;
-  height: 720px;
-  padding: 30px 30px 0;
-  margin: 60px auto 60px;
+  height: 680px;
+  margin-top: 120px;
+  margin-bottom: 120px;
   width: 800px;
   max-width: 95%;
   background: white;

--- a/src/contact.html
+++ b/src/contact.html
@@ -4,7 +4,7 @@ permalink: /contact/index.html
 class: contact
 ---
 
-<section class="contact-hero">
+<header class="contact-hero">
   <div class="contact-hero__intro container">
     <h1 class="contact-hero__title">Contact CAN&#8209;SWE</h1>
     <p class="contact-hero__lead">
@@ -12,7 +12,7 @@ class: contact
       <a href='/retailers'>contact your local CAN-SWE retailer.</a>
     </p>
   </div>
-</section>
+</header>
 
 <!-- POST louisritchie.com will return a 200. You can test the success alert that way !-->
 <form class="contact-page__form container" method="post" action="http://louisritchie.com" id="ajax-contact">

--- a/src/contact.html
+++ b/src/contact.html
@@ -7,7 +7,7 @@ class: contact
 <section class="contact-page__section">
   <header class="contact-hero">
     <div class="contact-hero__intro">
-      <h1 class="contact-hero__title">Contact CAN-SWE</h1>
+      <h1 class="contact-hero__title">Contact CAN&#8209;SWE</h1>
       <p class="contact-hero__lead">
         Use our contact form for wholesale inquiries. For retail inquiries, please
         <a href='/retailers'>contact your local CAN-SWE retailer.</a>

--- a/src/contact.html
+++ b/src/contact.html
@@ -4,15 +4,15 @@ permalink: /contact/index.html
 class: contact
 ---
 
-<header class="contact-hero">
-  <div class="contact-hero__intro">
+<section class="contact-hero">
+  <div class="contact-hero__intro container">
     <h1 class="contact-hero__title">Contact CAN&#8209;SWE</h1>
     <p class="contact-hero__lead">
       Use our contact form for wholesale inquiries. For retail inquiries, please
       <a href='/retailers'>contact your local CAN-SWE retailer.</a>
     </p>
   </div>
-</header>
+</section>
 
 <!-- POST louisritchie.com will return a 200. You can test the success alert that way !-->
 <form class="contact-page__form container" method="post" action="http://louisritchie.com" id="ajax-contact">

--- a/src/contact.html
+++ b/src/contact.html
@@ -4,50 +4,48 @@ permalink: /contact/index.html
 class: contact
 ---
 
-<section class="contact-page__section">
-  <header class="contact-hero">
-    <div class="contact-hero__intro">
-      <h1 class="contact-hero__title">Contact CAN&#8209;SWE</h1>
-      <p class="contact-hero__lead">
-        Use our contact form for wholesale inquiries. For retail inquiries, please
-        <a href='/retailers'>contact your local CAN-SWE retailer.</a>
-      </p>
-    </div>
-  </header>
+<header class="contact-hero">
+  <div class="contact-hero__intro">
+    <h1 class="contact-hero__title">Contact CAN&#8209;SWE</h1>
+    <p class="contact-hero__lead">
+      Use our contact form for wholesale inquiries. For retail inquiries, please
+      <a href='/retailers'>contact your local CAN-SWE retailer.</a>
+    </p>
+  </div>
+</header>
 
-  <!-- POST louisritchie.com will return a 200. You can test the success alert that way !-->
-  <form class="contact-page__form" method="post" action="http://louisritchie.com" id="ajax-contact">
-    <div class="contact-page__field">
-      <h2>Wholesale Inquiries Contact Form</h2>
-    </div>
+<!-- POST louisritchie.com will return a 200. You can test the success alert that way !-->
+<form class="contact-page__form container" method="post" action="http://louisritchie.com" id="ajax-contact">
+  <div class="contact-page__field">
+    <h2>Wholesale Inquiries Contact Form</h2>
+  </div>
 
-    <br />
+  <br />
 
-    <div class="contact-page__field">
-      <label for="name">Name</label>
-      <input name="name" id="name" />
-    </div>
- 
-    <div class="contact-page__field">
-      <label for="email">Email</label>
-      <input type="email" name="email" required id="email" />
-    </div>
- 
-    <div class="contact-page__field">
-      <label for="phone">Phone Number</label>
-      <input type="tel" name="phone" id="phone" />
-    </div>
- 
-    <div class="contact-page__textarea">
-      <label for="message">Your Message</label>
-      <textarea name="message" rows="8" required id="message"></textarea>
-    </div>
- 
-    <div class="contact-page__submit-wrapper">
-      <span>*Wholesale inquiries only</span>
-      <button class="button button--yellow" type="submit">Submit</button>
-    </div>
-  </form>
-</section>
+  <div class="contact-page__field">
+    <label for="name">Name</label>
+    <input name="name" id="name" />
+  </div>
+
+  <div class="contact-page__field">
+    <label for="email">Email</label>
+    <input type="email" name="email" required id="email" />
+  </div>
+
+  <div class="contact-page__field">
+    <label for="phone">Phone Number</label>
+    <input type="tel" name="phone" id="phone" />
+  </div>
+
+  <div class="contact-page__textarea">
+    <label for="message">Your Message</label>
+    <textarea name="message" rows="8" required id="message"></textarea>
+  </div>
+
+  <div class="contact-page__submit-wrapper">
+    <span>*Wholesale inquiries only</span>
+    <button class="button button--yellow" type="submit">Submit</button>
+  </div>
+</form>
 
 {% include components/map.html %}


### PR DESCRIPTION
- Stop the CAN-SWE text from breaking at the hyphen.
- use the "container" class instead of setting padding/width around certain items.
- Get rid of one level of HTML nesting.