### PR TITLE
Add Product Subcategories to products page

### DIFF
--- a/src/_data/categories.yml
+++ b/src/_data/categories.yml
@@ -23,6 +23,16 @@
 
     <p>Distinctive high visibility red or gold pocket flaps give an added
     margin of safety to the user.
+  sub-categories:
+    - name: 3600 TCS
+      safe: 3600
+      lead: Meets WCB PPE 1997
+    - name: 4100 TCS
+      safe: 4100
+      lead: Exceeds WCB PPE 1997
+    - name: Chaps
+      safe: chaps
+      lead: Meets WCB PPE 1997
 
 - name: Hurricane Rainwear
   safe: rainwear

--- a/src/_includes/components/products-page-product.html
+++ b/src/_includes/components/products-page-product.html
@@ -1,0 +1,12 @@
+<div class="product-grid__item-wrapper">
+  <a class="product-grid__item" href="{{ item.url }}">
+    <div class="product-grid__item-details">
+      <h2 class="product-grid__item-title">{{ item.title }}</h2>
+      <span class="product-grid__item-link">{{ item.mainmaterial }}</span>
+    </div>
+
+    <div class="product-grid__item-image">
+      {% include components/product-image.html item=item %}
+    </div>
+  </a>
+</div>

--- a/src/assets/css/_sass/components/_product-category.scss
+++ b/src/assets/css/_sass/components/_product-category.scss
@@ -16,6 +16,14 @@
   text-align: center;
 }
 
+.product-category__sub-category {
+  text-align: center;
+
+  @include screen($bp-tablet) {
+    text-align: left;
+  }
+}
+
 .product-category__title {
   font-weight: 600;
   text-transform: uppercase;

--- a/src/assets/css/_sass/components/_product-grid.scss
+++ b/src/assets/css/_sass/components/_product-grid.scss
@@ -1,7 +1,6 @@
 .product-grid {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
   @include flex-column-to-row($bp-tablet);
 }
 
@@ -16,6 +15,11 @@
 
   @include screen($bp-tablet) {
     flex-basis: calc((100% / 3) - 20px);
+  }
+
+  @include screen($bp-desktop) {
+    margin-right: 20px;
+    margin-left: 0;
   }
 }
 

--- a/src/assets/css/_sass/elements/_headings.scss
+++ b/src/assets/css/_sass/elements/_headings.scss
@@ -3,3 +3,7 @@
   Headings
 
 */
+
+.inline-header {
+  display: inline-block;
+}

--- a/src/products.index.html
+++ b/src/products.index.html
@@ -37,7 +37,6 @@ class: products
       <p class="product-category__lead">{{ category.lead }}</p>
     </header>
 
-
     <div class="product-category__article">
       <input type="checkbox" class="product-category__checkbox" name="{{ category.safe }}-toggle" id="{{ category.safe }}-toggle" />
 
@@ -48,12 +47,30 @@ class: products
       <label class="product-category__label" for="{{ category.safe }}-toggle">Read More {% include icons/logic-or.svg %}</label>
     </div>
 
-    <div class="product-category__grid product-grid">
-      {% for item in site.products %}
-        {% if item.category == category.safe %}
-          {% include components/products-page-product.html item=item %}
-        {% endif %}
+    {% if category.sub-categories %}
+      {% for sub-cat in category.sub-categories %}
+        <header class="product-category__sub-category">
+          <h3 class="inline-header">{{ sub-cat.name }}</h3> {{ sub-cat.lead }}
+        </header>
+
+        <div class="product-category__grid product-grid">
+          {% for item in site.products %}
+            {% if item.category == category.safe %}
+              {% if item.sub-category == sub-cat.safe %}
+                {% include components/products-page-product.html item=item %}
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+        </div>
       {% endfor %}
-    </div>
+    {% else %}
+      <div class="product-category__grid product-grid">
+        {% for item in site.products %}
+          {% if item.category == category.safe %}
+            {% include components/products-page-product.html item=item %}
+          {% endif %}
+        {% endfor %}
+      </div>
+    {% endif %}
   </div>
 {% endfor %}

--- a/src/products.index.html
+++ b/src/products.index.html
@@ -51,18 +51,7 @@ class: products
     <div class="product-category__grid product-grid">
       {% for item in site.products %}
         {% if item.category == category.safe %}
-          <div class="product-grid__item-wrapper">
-            <a class="product-grid__item" href="{{ item.url }}">
-              <div class="product-grid__item-details">
-                <h2 class="product-grid__item-title">{{ item.title }}</h2>
-                <span class="product-grid__item-link">{{ item.mainmaterial }}</span>
-              </div>
-
-              <div class="product-grid__item-image">
-                {% include components/product-image.html item=item %}
-              </div>
-            </a>
-          </div>
+          {% include components/products-page-product.html item=item %}
         {% endif %}
       {% endfor %}
     </div>


### PR DESCRIPTION
Adds the concept of a sub-category, through categories.yml
Using a loop inside of our existing category loop, find items for the necessary sub category.
Bonus - extracted the grid item to a new component for reuse

<img width="1028" alt="screen shot 2019-02-11 at 7 31 27 pm" src="https://user-images.githubusercontent.com/43543/52609870-a7817600-2e33-11e9-90bb-9126d7746329.png">
